### PR TITLE
Refine PHPStan type definitions and enhance interfaces

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 namespace RequestInterop\Interface;
 
 /**
- * @phpstan-import-type BodyResource from Body
  * @phpstan-import-type CookiesArray from Request
  * @phpstan-import-type FilesArray from Request
- * @phpstan-import-type FilesArrayItem from Request
- * @phpstan-import-type FilesArrayGroup from Request
  * @phpstan-import-type HeadersArray from Request
  * @phpstan-import-type InputArray from Request
- * @phpstan-import-type MethodString from Request
+ * @phpstan-import-type HttpMethod from Request
  * @phpstan-import-type QueryArray from Request
  * @phpstan-import-type ServerArray from Request
  * @phpstan-import-type UploadsArray from Request
+ * @phpstan-import-type HttpUploadErrorCode from Request
  */
 interface Factory
 {
@@ -23,13 +21,12 @@ interface Factory
      * @param ?FilesArray $files
      * @param ?HeadersArray $headers
      * @param ?InputArray $input
-     * @param ?InputArray $input
-     * @param ?MethodString $method
+     * @param ?HttpMethod $method
      * @param ?QueryArray $query
      * @param ?ServerArray $server
      * @param ?UploadsArray $uploads
-     * @param ?BodyResource $body
      * @return Request|(Request&Body)
+     * @throws FactoryException
      */
     public function newRequest(
         ?array $cookies = null,
@@ -45,8 +42,14 @@ interface Factory
     ) : Request;
 
     /**
-     * @param ?BodyResource $body
+     * @param non-empty-string $tmpName
+     * @param HttpUploadErrorCode $error
+     * @param non-empty-string|null $name
+     * @param non-empty-string|null $fullPath
+     * @param non-empty-string|null $type
+     * @param positive-int|null $size
      * @return Upload|(Upload&Body)
+     * @throws FactoryException
      */
     public function newUpload(
         string $tmpName,
@@ -58,6 +61,17 @@ interface Factory
         mixed $body = null,
     ) : Upload;
 
+    /**
+     * @param HttpScheme|null $scheme
+     * @param non-empty-string|null $host
+     * @param NetworkPort|null $port
+     * @param non-empty-string|null $user
+     * @param non-empty-string|null $pass
+     * @param non-empty-string|null $path
+     * @param non-empty-string|null $query
+     * @param non-empty-string|null $fragment
+     * @throws FactoryException
+     */
     public function newUrl(
         ?string $scheme = null,
         ?string $host = null,

--- a/src/Request.php
+++ b/src/Request.php
@@ -6,39 +6,43 @@ namespace RequestInterop\Interface;
 /**
  * @phpstan-type CookiesArray array<string, string>
  *
- * @phpstan-type FilesArray mixed[]
+ * @phpstan-type FilesArrayValue FilesArrayItem|FilesArrayGroup|FilesArray
+ * @phpstan-type FilesArray array<array-key, FilesArrayValue>
  *
  * @phpstan-type FilesArrayItem array{
- *     tmp_name:string,
- *     error:int,
- *     name?:string,
- *     full_path?:string,
- *     type?:string,
- *     size?:int,
+ *     tmp_name: non-empty-string,
+ *     error: HttpUploadErrorCode,
+ *     name?: non-empty-string,
+ *     full_path?: non-empty-string,
+ *     type?: non-empty-string,
+ *     size?: positive-int
  * }
  *
  * @phpstan-type FilesArrayGroup array{
- *     tmp_name:string[],
- *     error:int[],
- *     name?:string[],
- *     full_path?:string[],
- *     type?:string[],
- *     size?:int[],
+ *     tmp_name: array<int, non-empty-string>,
+ *     error: array<int, HttpUploadErrorCode>,
+ *     name?: array<int, non-empty-string>,
+ *     full_path?: array<int, non-empty-string>,
+ *     type?: array<int, non-empty-string>,
+ *     size?: array<int, positive-int>
  * }
  *
- * @phpstan-type HeadersArray array<lowercase-string, string>
+ * @phpstan-type HeadersArray array<lowercase-string, non-empty-string>
  *
- * @phpstan-type InputArray mixed[]
+ * @phpstan-type InputArrayValue null|scalar|InputArray
+ * @phpstan-type InputArray array<array-key, InputArrayValue>
  *
- * @phpstan-type ScalarArray mixed[]
+ * @phpstan-type HttpMethod 'GET'|'POST'|'PUT'|'DELETE'|'HEAD'|'OPTIONS'|'PATCH'|'TRACE'|'CONNECT'
  *
- * @phpstan-type MethodString uppercase-string
+ * @phpstan-type QueryArrayValue string|QueryArray
+ * @phpstan-type QueryArray array<array-key, QueryArrayValue>
  *
- * @phpstan-type QueryArray mixed[]
+ * @phpstan-type ServerArray array<non-empty-string, string>
  *
- * @phpstan-type ServerArray array<string, string>
+ * @phpstan-type UploadsArrayValue Upload|UploadsArray
+ * @phpstan-type UploadsArray array<array-key, UploadsArrayValue>
  *
- * @phpstan-type UploadsArray mixed[]
+ * @phpstan-type HttpUploadErrorCode int<0, 8>
  */
 interface Request
 {
@@ -54,7 +58,7 @@ interface Request
     /** @var InputArray */
     public array $input { get; }
 
-    /** @var MethodString */
+    /** @var HttpMethod */
     public string $method { get; }
 
     /** @var QueryArray */

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace RequestInterop\Interface;
+
+use Stringable;
+
+/**
+ * @phpstan-type StreamPosition int<0, max>
+ * @phpstan-type StreamWhence SEEK_SET|SEEK_CUR|SEEK_END
+ * @phpstan-type StreamLength positive-int
+ * @phpstan-type StreamContent non-empty-string
+ */
+interface Stream extends Stringable
+{
+    /**
+     * @return StreamPosition
+     * @throws StreamException
+     */
+    public function tell(): int;
+
+    /**
+     * @param StreamLength $length
+     * @return StreamContent
+     * @throws StreamException
+     */
+    public function read(int $length): string;
+
+    /**
+     * @param StreamPosition $offset
+     * @param StreamWhence $whence
+     * @throws StreamException
+     */
+    public function seek(int $offset, int $whence = SEEK_SET): void;
+
+    public function eof(): bool;
+
+    /**
+     * @return StreamContent
+     * @throws StreamException
+     */
+    public function __toString(): string;
+}

--- a/src/Upload.php
+++ b/src/Upload.php
@@ -3,19 +3,37 @@ declare(strict_types=1);
 
 namespace RequestInterop\Interface;
 
+/**
+ * @phpstan-import-type HttpUploadErrorCode from Request
+ */
 interface Upload
 {
+    /** @var non-empty-string */
     public string $tmpName { get; }
 
+    /** @var HttpUploadErrorCode */
     public int $error { get; }
 
+    /** @var non-empty-string|null */
     public ?string $name { get; }
 
+    /** @var non-empty-string|null */
     public ?string $fullPath { get; }
 
+    /** @var non-empty-string|null */
     public ?string $type { get; }
 
+    /** @var positive-int|null */
     public ?int $size { get; }
 
-    public function move(string $to) : bool;
+    /**
+     * @param non-empty-string $to
+     * @throws UploadException
+     */
+    public function move(string $to): bool;
+
+    /**
+     * @throws StreamException
+     */
+    public function getStream(): Stream;
 }

--- a/src/Url.php
+++ b/src/Url.php
@@ -6,34 +6,45 @@ namespace RequestInterop\Interface;
 use Stringable;
 
 /**
+ * @phpstan-type NetworkPort int<1, 65535>
+ * @phpstan-type HttpScheme 'http'|'https'
  * @phpstan-type UrlArray array{
- *    scheme:?string,
- *    user:?string,
- *    pass:?string,
- *    host:?string,
- *    port:?int,
- *    path:?string,
- *    query:?string,
- *    fragment:?string
+ *     scheme: HttpScheme|null,
+ *     user: non-empty-string|null,
+ *     pass: non-empty-string|null,
+ *     host: non-empty-string|null,
+ *     port: NetworkPort|null,
+ *     path: non-empty-string|null,
+ *     query: non-empty-string|null,
+ *     fragment: non-empty-string|null
  * }
  */
 interface Url extends Stringable
 {
+    /** @var HttpScheme|null */
     public ?string $scheme { get; }
 
+    /** @var non-empty-string|null */
     public ?string $host { get; }
 
+    /** @var NetworkPort|null */
     public ?int $port { get; }
 
+    /** @var non-empty-string|null */
     public ?string $user { get; }
 
+    /** @var non-empty-string|null */
     public ?string $pass { get; }
 
+    /** @var non-empty-string|null */
     public ?string $path { get; }
 
+    /** @var non-empty-string|null */
     public ?string $query { get; }
 
+    /** @var non-empty-string|null */
     public ?string $fragment { get; }
 
+    /** @return non-empty-string */
     public function __toString() : string;
 }


### PR DESCRIPTION
This commit improves type safety by refining PHPStan type definitions across Request, Upload, Factory, and Url classes. It introduces stricter types like non-empty-string, positive-int, and HttpUploadErrorCode, enhancing code reliability. Additionally, it adds missing annotations and throws declarations to methods, increasing clarity and error handling.